### PR TITLE
docs: update link on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # HabboAPI v.3.3.6
-Documentation: [HabboAPI.net](https://habboapi.net/).
+Documentation: [HabboAPI.co](https://habboapi.co/).
 
 The HabboAPI is a free to use API, that aim to help Habbo fansite builders create awesome tools and features for their fansites. We offer a large number of API endpoints, that serve you the lastest Habbo Badges, Furniture, Clothes and hopefully a lot more, in the future.
 
@@ -17,4 +17,4 @@ There's **no** Rate-limiting enforced in our API.
 Made by [Incor](https://github.com/inctor) and [HabboAPI](https://github.com/habboapi).
 
 ## Changelog
-Latest: [Changelog](https://habboapi.net/changelog).
+Latest: [Changelog](https://habboapi.co/changelog).


### PR DESCRIPTION
Update README file with the new HabboAPI link